### PR TITLE
Add Microsoft OAuth login and standard GraphQL endpoint

### DIFF
--- a/graph/server.js
+++ b/graph/server.js
@@ -6,9 +6,11 @@ const { NoSQL } = require('./src/db/NoSQL');
 const { parse, execute } = require('./src/graphql');
 const { PKISystem } = require('./src/pki');
 const HttpService = require('./src/services/HttpService');
+const { URL } = require('url');
+
+const isProduction = process.env.NODE_ENV === 'production';
 
 (async () => {
-  // --- init infra ---
   const db = new NoSQL();
   await db.init();
 
@@ -19,10 +21,8 @@ const HttpService = require('./src/services/HttpService');
 
   const pki = new PKISystem();
 
-  // AuthService: dev memory token store by default here
   const authService = new AuthService({ db, pki, smtp, persistTokens: false });
 
-  // HttpService instance (uses your new compact API)
   const http = new HttpService(authService, {
     publicPath: path.join(__dirname, 'public'),
     pagesPath: path.join(__dirname, 'public', 'pages'),
@@ -32,9 +32,67 @@ const HttpService = require('./src/services/HttpService');
     allowedOrigins: ['https://fitfak.net']
   });
 
-  // ---------------- Auth GraphQL schema ----------------
-  // note: resolvers receive context: { db, req, res, authService, http, user }
-  const authSchema = {
+  const cookieDefaults = {
+    name: 'auth_token',
+    ttlMs: authService.tokenTTL,
+    sameSite: isProduction ? 'None' : 'Lax',
+    secure: isProduction,
+    httpOnly: true,
+    path: '/'
+  };
+
+  const graphSchema = {
+    Query: {
+      me: {
+        auth: true,
+        resolve: async (_p, _args, { req, db }) => {
+          const user = await db.findOne('users', { id: req.user.id });
+          if (!user) return { success: false, message: 'User not found' };
+          const { name, surname, schoolNumber, role, email } = user;
+          return { success: true, data: { id: req.user.id, name, surname, schoolNumber, role, email } };
+        }
+      },
+      event: {
+        auth: true,
+        resolve: async (_p, { id }, { db }) => {
+          const doc = await db.findOne('events', { id });
+          return doc ? { __type: 'Event', ...doc } : null;
+        }
+      },
+      events: {
+        auth: true,
+        resolve: async (_p, { ownerId, tag }, { db }) => {
+          const filter = {};
+          if (ownerId) filter.ownerId = ownerId;
+          if (tag) filter.tags = { $in: [tag] };
+          const list = await db.find('events', filter, { limit: 200, sort: (a, b) => a.startsAt.localeCompare(b.startsAt) });
+          return list.map(e => ({ __type: 'Event', ...e }));
+        }
+      },
+      microsoftAuthorizationUrl: {
+        auth: false,
+        resolve: (_p, args = {}, { authService }) => {
+          if (!authService.microsoftConfigValid()) {
+            return { success: false, message: 'Microsoft OAuth yapılandırması eksik.' };
+          }
+
+          const payload = (args.statePayload && typeof args.statePayload === 'object') ? args.statePayload : {};
+          if (args.origin) payload.origin = args.origin;
+
+          const { url, state } = authService.buildMicrosoftAuthorizationUrl({
+            state: args.state,
+            statePayload: Object.keys(payload).length ? payload : undefined,
+            prompt: args.prompt,
+            loginHint: args.loginHint,
+            domainHint: args.domainHint,
+            codeChallenge: args.codeChallenge,
+            codeChallengeMethod: args.codeChallengeMethod
+          });
+
+          return { success: true, data: { url, state } };
+        }
+      }
+    },
     Mutation: {
       register: {
         auth: false,
@@ -43,76 +101,46 @@ const HttpService = require('./src/services/HttpService');
             const { success, userId, tokenSent } = await authService.register(args);
             return {
               success,
-              data: tokenSent ? 'Doğrulama bağlantısı e-posta ile gönderildi.' : 'Kayıt oluşturuldu (test token üretildi).'
+              data: tokenSent ? 'Doğrulama bağlantısı e-posta ile gönderildi.' : 'Kayıt oluşturuldu (test token üretildi).',
+              userId
             };
           } catch (e) {
             return { success: false, message: e.message };
           }
         }
       },
-
       login: {
         auth: false,
-        resolve: async (_p, { email, password }, { authService, req, res }) => {
-          const result = await authService.login(email, password);
-          if (!result.success) return { success: false, message: result.message };
-
-          const token = result.data.token;
-          // return minimal info (token optional)
-          return { success: true, data: { token } };
+        resolve: async (_p, { email, password }, { authService, res }) => {
+          try {
+            const result = await authService.login(email, password);
+            if (!result.success) return result;
+            const token = result.data?.token;
+            if (token) authService.setAuthCookieOnResponse(res, token, cookieDefaults);
+            return result;
+          } catch (e) {
+            return { success: false, message: e.message };
+          }
         }
       },
       session: {
-  auth: false,
-  resolve: async (_p, { token }, { authService, res, req, db }) => {
-    try {
-      // 1) Doğrula
-      const payload = await authService.verifyJWT(token);
-
-      if (!payload) return { success: false, message: 'Invalid or expired token' };
-
-      // 2) (Opsiyonel) DB'den kullanıcı bilgisi çekme — isterseniz kullanın
-      let user = null;
-      try {
-        if (authService.db && payload.id) {
-          user = await authService.db.findOne('users', { id: payload.id });
+        auth: false,
+        resolve: async (_p, { token }, { authService, res }) => {
+          try {
+            const payload = await authService.verifyJWT(token);
+            if (!payload) return { success: false, message: 'Invalid or expired token' };
+            authService.setAuthCookieOnResponse(res, token, cookieDefaults);
+            return { success: true, message: 'Cookie set' };
+          } catch (e) {
+            return { success: false, message: e.message };
+          }
         }
-      } catch (e) {
-        console.warn('[SESSION] db lookup failed', e && e.message);
-      }
-
-      // 3) Cookie ayarları
-      // DEV: cross-origin test yapıyorsanız SameSite: 'Lax', secure: false kullanın.
-      // PROD (cross-site): SameSite: 'None' ve secure: true (HTTPS) olmalı.
-      authService.setAuthCookieOnResponse(res, token, {
-        name: 'auth_token',
-        ttlMs: authService.tokenTTL,
-        sameSite: (process.env.NODE_ENV === 'production') ? 'None' : 'Lax',
-        secure: (process.env.NODE_ENV === 'production'),
-        httpOnly: true,
-        path: '/'
-      });
-
-      // 4) hemen Set-Cookie header'ını logla (debug)
-      try {
-        const sc = (res.getHeader && res.getHeader('Set-Cookie')) || null;
-      } catch (e) {
-        console.log('[SESSION] could not read res.getHeader("Set-Cookie")', e && e.message);
-      }
-
-      return { success: true, message: 'Cookie set' };
-    } catch (e) {
-      return { success: false, message: e.message };
-    }
-  }
-},
-
-
+      },
       requestPasswordReset: {
         auth: false,
         resolve: async (_p, { email, originUrl }, { req, authService }) => {
           try {
-            const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
+            const ip = req.ip || req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
             const result = await authService.requestPasswordReset(email, ip, originUrl);
             if (!result.success) return { success: false, message: result.message };
             return { success: true, message: result.tokenSent ? 'Şifre sıfırlama bağlantısı e-posta ile gönderildi.' : 'Şifre sıfırlama tokenı oluşturuldu.' };
@@ -121,7 +149,6 @@ const HttpService = require('./src/services/HttpService');
           }
         }
       },
-
       resetPassword: {
         auth: false,
         resolve: async (_p, { token, newPassword }, { authService }) => {
@@ -134,7 +161,6 @@ const HttpService = require('./src/services/HttpService');
           }
         }
       },
-
       verifyEmail: {
         auth: false,
         resolve: async (_p, { token }, { authService }) => {
@@ -146,116 +172,31 @@ const HttpService = require('./src/services/HttpService');
             return { success: false, message: e.message };
           }
         }
-      }
-    }
-  };
-
-  // ---------------- /graph/auth proxy ----------------
-  http.addRoute('POST', '/graph/auth', async (req, res) => {
-    try {
-      const { query, variables } = req.body || {};
-      if (!query) return http.sendJson(res, 400, { success: false, message: 'GraphQL query gerekli.' });
-
-      const ast = parse(query);
-      const result = await execute({
-        schema: authSchema,
-        document: ast,
-        variableValues: variables,
-        // pass res + http + authService so resolvers can set cookies / headers
-        contextValue: { db, req, res, authService, http, user: req.user }
-      });
-
-      return http.sendGraph(res, 200, result);
-    } catch (e) {
-      return http.sendJson(res, 400, { success: false, message: e.message });
-    }
-  }, { auth: false, graph: true });
-
-
-const sessionSchema = {
-  Query: {
-    me: {
-      auth: true,
-      resolve: async (_p, _args, { req, db }) => {
-        const user = await db.findOne('users', { id: req.user.id });
-
-        if (!user) return { success: false, message: 'User not found' };
-
-        // Sadece gerekli alanları döndür
-        const { name, surname, schoolNumber, role } = user;
-
-        return {
-          success: true,
-          data: { id: req.user.id, name, surname, schoolNumber, role }
-        };
-      }
-    }
-  },
-  Mutation: {
+      },
+      completeMicrosoftLogin: {
+        auth: false,
+        resolve: async (_p, { code, state, codeVerifier }, { authService, res }) => {
+          try {
+            const result = await authService.handleMicrosoftCallback({ code, state, codeVerifier });
+            if (result.success && result.data?.token) {
+              authService.setAuthCookieOnResponse(res, result.data.token, cookieDefaults);
+            }
+            return result;
+          } catch (e) {
+            return { success: false, message: e.message };
+          }
+        }
+      },
       logout: {
         auth: true,
         resolve: async (_p, _args, { authService, req, res }) => {
-          // optional: revoke tokens server-side if implemented
           if (typeof authService.revokeToken === 'function') {
             try { await authService.revokeToken(req.user?.id); } catch (e) { /* ignore */ }
           }
-
-          // clear cookie
-          authService.clearAuthCookieOnResponse(res, 'auth_token', {
-            sameSite: 'Strict',
-            secure: process.env.NODE_ENV === 'production',
-            httpOnly: true,
-            path: '/'
-          });
-
+          authService.clearAuthCookieOnResponse(res, cookieDefaults.name, cookieDefaults);
           return { success: true, message: 'Logged out' };
         }
-      }
-  }
-};
-
-
-http.addRoute('POST', '/graph/auth/session', async (req, res) => {
-    try {
-      const { query, variables } = req.body || {};
-      if (!query) return http.sendJson(res, 400, { success: false, message: 'GraphQL query gerekli.' });
-
-      const ast = parse(query);
-      const result = await execute({
-        schema: sessionSchema,
-        document: ast,
-        variableValues: variables,
-        // pass res + http + authService so resolvers can set cookies / headers
-        contextValue: { db, req, res, authService, http, user: req.user }
-      });
-
-      return http.sendGraph(res, 200, result);
-    } catch (e) {
-      return http.sendJson(res, 400, { success: false, message: e.message });
-    }
-  }, { auth: true, graph: true });
-  // ---------------- General /graphql endpoint ----------------
-  const schema = {
-    Query: {
-      event: {
-        type: 'Event',
-        resolve: async (_p, { id }, { db }) => {
-          const doc = await db.findOne('events', { id });
-          return doc ? { __type: 'Event', ...doc } : null;
-        }
       },
-      events: {
-        type: '[Event!]',
-        resolve: async (_p, { ownerId, tag }, { db }) => {
-          const filter = {};
-          if (ownerId) filter.ownerId = ownerId;
-          if (tag) filter.tags = { $in: [tag] };
-          const list = await db.find('events', filter, { limit: 200, sort: (a, b) => a.startsAt.localeCompare(b.startsAt) });
-          return list.map(e => ({ __type: 'Event', ...e }));
-        }
-      }
-    },
-    Mutation: {
       createEvent: {
         type: 'Event',
         auth: true,
@@ -287,24 +228,70 @@ http.addRoute('POST', '/graph/auth/session', async (req, res) => {
     types: { Event: {} }
   };
 
-  http.addRoute('POST', '/graph', async (req, res) => {
-    const { query, variables } = req.body || {};
-    if (!query) return http.sendJson(res, 400, { error: 'query required' });
-    try {
-      const ast = parse(query);
-      const result = await execute({
-        schema,
-        document: ast,
-        variableValues: variables,
-        contextValue: { db, req, res, authService, http, user: req.user }
-      });
-      return http.sendGraph(res, 200, result);
-    } catch (e) {
-      return http.sendJson(res, 400, { error: e.message });
-    }
-  }, { auth: true, graph: true });
+  const registerGraphEndpoint = (pathPattern) => {
+    http.registerGraphQL(pathPattern, {
+      schema: graphSchema,
+      parse,
+      execute,
+      contextFactory: () => ({ db, authService })
+    });
+  };
 
-  // ---------------- PKI sign/verify ----------------
+  registerGraphEndpoint('/graphql');
+  registerGraphEndpoint('/graph');
+
+  http.addRoute('GET', '/auth/microsoft', (req, res) => {
+    if (!authService.microsoftConfigValid()) {
+      return http.sendJson(res, 503, { success: false, message: 'Microsoft OAuth yapılandırması yapılmadı.' });
+    }
+
+    const parsedUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    const origin = parsedUrl.searchParams.get('origin');
+    const prompt = parsedUrl.searchParams.get('prompt');
+    const loginHint = parsedUrl.searchParams.get('login_hint');
+    const domainHint = parsedUrl.searchParams.get('domain_hint');
+
+    const statePayload = {};
+    if (origin) statePayload.origin = origin;
+
+    const { url: redirectUrl } = authService.buildMicrosoftAuthorizationUrl({
+      statePayload: Object.keys(statePayload).length ? statePayload : undefined,
+      prompt,
+      loginHint,
+      domainHint
+    });
+
+    return http.redirectHtml(res, redirectUrl, 302);
+  });
+
+  http.addRoute('GET', '/auth/microsoft/callback', async (req, res) => {
+    const parsedUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    const error = parsedUrl.searchParams.get('error');
+    const errorDescription = parsedUrl.searchParams.get('error_description');
+    if (error) {
+      return http.sendHtml(res, 400, `<h1>Microsoft OAuth hatası</h1><p>${error}: ${errorDescription || ''}</p>`);
+    }
+
+    const code = parsedUrl.searchParams.get('code');
+    const state = parsedUrl.searchParams.get('state');
+    if (!code) {
+      return http.sendHtml(res, 400, '<h1>Eksik Microsoft kodu</h1>');
+    }
+
+    try {
+      const result = await authService.handleMicrosoftCallback({ code, state });
+      if (result.success && result.data?.token) {
+        authService.setAuthCookieOnResponse(res, result.data.token, cookieDefaults);
+      }
+
+      const stateInfo = result.data?.state;
+      const redirectTarget = (stateInfo && stateInfo.origin) ? stateInfo.origin : '/';
+      return http.redirectHtml(res, redirectTarget, 302);
+    } catch (e) {
+      return http.sendHtml(res, 500, `<h1>Microsoft OAuth işlemi başarısız</h1><p>${e.message}</p>`);
+    }
+  });
+
   http.addRoute('POST', '/sign', async (req, res) => {
     const { payload } = req.body || {};
     if (!payload) return http.sendJson(res, 400, { success: false, message: 'Missing payload' });
@@ -325,9 +312,8 @@ http.addRoute('POST', '/graph/auth/session', async (req, res) => {
     } catch (e) {
       return http.sendJson(res, 400, { success: false, message: e.message });
     }
-  }, { auth: true, roles: ['admin','user'] });
+  }, { auth: true, roles: ['admin', 'user'] });
 
-  // ---------------- HTML upload route ----------------
   http.addRoute('POST', '/html', async (req, res) => {
     if (!req.body || !req.body.files) return http.sendJson(res, 400, { success: false, files: [] });
     const files = req.body.files.map(f => ({ field: f.fieldname, filename: f.filename }));
@@ -345,7 +331,6 @@ http.addRoute('POST', '/graph/auth/session', async (req, res) => {
     }
   });
 
-  // ---------------- start server ----------------
   const port = process.env.PORT || 80;
   http.listen(port, () => console.log(`Server listening on ${port}`));
 })();

--- a/graph/src/db/schemas.js
+++ b/graph/src/db/schemas.js
@@ -38,9 +38,14 @@ const SCHEMAS = {
       name:  { type: 'String', required: true },
       surname: { type: 'String' },
       schoolNumber: { type: 'String' },
-      passwordHash: { type: 'String', required: true },
+      passwordHash: { type: 'String' },
       role: { type: 'String', default: 'user' },
-      verified: { type: 'Boolean', default: false }
+      verified: { type: 'Boolean', default: false },
+      authProvider: { type: 'String' },
+      microsoftId: { type: 'String' },
+      microsoftTenantId: { type: 'String' },
+      microsoftRefreshToken: { type: 'String' },
+      lastMicrosoftLogin: { type: 'Date' }
     }
   }
 };


### PR DESCRIPTION
## Summary
- integrate Microsoft OAuth flows in the auth service, including token exchange, profile sync, certificate issuance, and cookie helpers
- extend the user schema and GraphQL executor to support Microsoft metadata and named operations
- rebuild the server GraphQL wiring around a spec-compliant HttpService GraphQL handler and add Microsoft auth redirect/callback routes

## Testing
- `node -e "require('./graph/src/services/AuthService'); console.log('AuthService ok');"`
- `node -e "require('./graph/src/services/HttpService'); console.log('HttpService ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68e2434a194c8320b1be178082818f6a